### PR TITLE
Feat: Caching Sidecar requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,17 @@
             "RobertBoes\\SidecarInertiaVite\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "RobertBoes\\SidecarInertiaVite\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "vendor/bin/phpunit --coverage",
+        "format": "vendor/bin/pint"
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/config/config.php
+++ b/config/config.php
@@ -1,5 +1,6 @@
 <?php
 
+use RobertBoes\SidecarInertiaVite\Cache\PageHashStrategy;
 use RobertBoes\SidecarInertiaVite\SSRFunction;
 
 return [
@@ -22,4 +23,10 @@ return [
 
     // Compile Ziggy routes with the Lambda function.
     'ziggy' => false,
+
+    'cache' => [
+        'enabled' => env('SIDECAR_INERTIA_VITE_CACHE_ENABLED', false),
+        'strategy' => PageHashStrategy::class,
+        'ttl' => 30,
+    ],
 ];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd"
+    backupGlobals="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
+>
+    <testsuites>
+        <testsuite name="RobertBoes/SidecarInertiaVite Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Cache/CacheStrategy.php
+++ b/src/Cache/CacheStrategy.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace RobertBoes\SidecarInertiaVite\Cache;
+
+use Hammerstone\Sidecar\LambdaFunction;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+
+abstract class CacheStrategy
+{
+    abstract public function store(array $page, array $result): void;
+
+    abstract public function get(array $page): ?array;
+
+    public function execute(array $page, LambdaFunction $handler): array
+    {
+        if (! Config::get('sidecar-inertia-vite.cache.enabled', false)) {
+            return $this->result($page, $handler);
+        }
+
+        if ($result = $this->get($page)) {
+            return $result;
+        }
+
+        return tap(
+            value: $this->result($page, $handler),
+            callback: fn (array $result) => $this->store($page, $result),
+        );
+    }
+
+    protected function result(array $page, LambdaFunction $handler): array
+    {
+        $result = $handler::execute($page)->throw();
+
+        if (Config::get('sidecar-inertia-vite.timings')) {
+            Log::info('Sending SSR request to Lambda', $result->report());
+        }
+
+        return $result->body();
+    }
+}

--- a/src/Cache/PageHashStrategy.php
+++ b/src/Cache/PageHashStrategy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace RobertBoes\SidecarInertiaVite\Cache;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+
+class PageHashStrategy extends CacheStrategy
+{
+    public function store(array $page, array $result): void
+    {
+        Cache::put($this->key($page), $result, Config::get('sidecar-inertia-vite.cache.ttl', 30));
+    }
+
+    public function get(array $page): ?array
+    {
+        return Cache::get($this->key($page));
+    }
+
+    private function key(array $page): string
+    {
+        return 'sidecar:inertia-vite:'.hash('sha256', serialize($page));
+    }
+}

--- a/src/SSRFunction.php
+++ b/src/SSRFunction.php
@@ -11,17 +11,17 @@ use Symfony\Component\Process\Process;
 
 class SSRFunction extends LambdaFunction
 {
-    public function name()
+    public function name(): string
     {
         return Config::get('sidecar-inertia-vite.name', 'Inertia-SSR-Vite');
     }
 
-    public function runtime()
+    public function runtime(): string
     {
         return Config::get('sidecar-inertia-vite.runtime', Runtime::NODEJS_16);
     }
 
-    public function memory()
+    public function memory(): int
     {
         return Config::get('sidecar-inertia-vite.memory', 1024);
     }
@@ -31,7 +31,7 @@ class SSRFunction extends LambdaFunction
         return $this->shouldBundle() ? 'index.handler' : 'ssr.handler';
     }
 
-    public function package()
+    public function package(): Package
     {
         if ($this->shouldBundle()) {
             return Package::make()
@@ -51,7 +51,7 @@ class SSRFunction extends LambdaFunction
         return $package;
     }
 
-    public function beforeDeployment()
+    public function beforeDeployment(): void
     {
         Sidecar::log('Executing beforeDeployment hooks');
 

--- a/src/SSRFunction.php
+++ b/src/SSRFunction.php
@@ -26,7 +26,7 @@ class SSRFunction extends LambdaFunction
         return Config::get('sidecar-inertia-vite.memory', 1024);
     }
 
-    public function handler()
+    public function handler(): string
     {
         return $this->shouldBundle() ? 'index.handler' : 'ssr.handler';
     }

--- a/src/SSRFunction.php
+++ b/src/SSRFunction.php
@@ -7,7 +7,7 @@ use Hammerstone\Sidecar\Package;
 use Hammerstone\Sidecar\Runtime;
 use Hammerstone\Sidecar\Sidecar;
 use Illuminate\Support\Facades\Config;
-use Symfony\Component\Process\Process;
+use Illuminate\Support\Facades\Process;
 
 class SSRFunction extends LambdaFunction
 {
@@ -74,10 +74,12 @@ class SSRFunction extends LambdaFunction
 
         Sidecar::log("Build: Running \"{$command}\"");
 
-        $process = new Process(explode(' ', $command), $cwd = base_path(), $env = []);
-
-        // mustRun will throw an exception if it fails, which is what we want.
-        $process->setTimeout(60)->disableOutput()->mustRun();
+        Process::newPendingProcess()
+            ->timeout(60)
+            ->path(base_path())
+            ->quietly()
+            ->run($command)
+            ->throw();
 
         Sidecar::log('Build: JavaScript SSR bundle compiled!');
     }
@@ -96,10 +98,12 @@ class SSRFunction extends LambdaFunction
 
         Sidecar::log("Optimizing bundle: Running \"{$command}\"");
 
-        $process = new Process(explode(' ', $command), $cwd = base_path(), $env = []);
-
-        // mustRun will throw an exception if it fails, which is what we want.
-        $process->setTimeout(60)->disableOutput()->mustRun();
+        Process::newPendingProcess()
+            ->timeout(60)
+            ->path(base_path())
+            ->quietly()
+            ->run($command)
+            ->throw();
 
         Sidecar::log('Optimizing bundle: Package bundled with NCC!');
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,8 @@ namespace RobertBoes\SidecarInertiaVite;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Inertia\Ssr\Gateway;
+use RobertBoes\SidecarInertiaVite\Cache\PageHashStrategy;
+use RobertBoes\SidecarInertiaVite\Cache\CacheStrategy;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -22,7 +24,17 @@ class ServiceProvider extends BaseServiceProvider
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'sidecar-inertia-vite');
 
         if (Config::get('sidecar-inertia-vite.ssr_gateway_enabled', false)) {
-            $this->app->instance(Gateway::class, new SidecarGateway());
+            $this->app->bind(
+                abstract: Gateway::class,
+                concrete: SidecarGateway::class,
+            );
+        }
+
+        if (Config::get('sidecar-inertia-vite.cache.enabled', false)) {
+            $this->app->bind(
+                abstract: CacheStrategy::class,
+                concrete: Config::get('sidecar-inertia-vite.cache.strategy', PageHashStrategy::class),
+            );
         }
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,8 +5,8 @@ namespace RobertBoes\SidecarInertiaVite;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Inertia\Ssr\Gateway;
-use RobertBoes\SidecarInertiaVite\Cache\PageHashStrategy;
 use RobertBoes\SidecarInertiaVite\Cache\CacheStrategy;
+use RobertBoes\SidecarInertiaVite\Cache\PageHashStrategy;
 
 class ServiceProvider extends BaseServiceProvider
 {

--- a/src/SidecarGateway.php
+++ b/src/SidecarGateway.php
@@ -5,7 +5,6 @@ namespace RobertBoes\SidecarInertiaVite;
 use Exception;
 use Hammerstone\Sidecar\LambdaFunction;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Log;
 use Inertia\Ssr\Gateway;
 use Inertia\Ssr\Response;
 use RobertBoes\SidecarInertiaVite\Cache\CacheStrategy;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace RobertBoes\SidecarInertiaVite\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+use RobertBoes\SidecarInertiaVite\ServiceProvider as SidecarInertiaViteProvider;
+
+class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            SidecarInertiaViteProvider::class,
+        ];
+    }
+
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,5 +13,4 @@ class TestCase extends Orchestra
             SidecarInertiaViteProvider::class,
         ];
     }
-
 }


### PR DESCRIPTION
This is very much a WIP as I'm still not sure about the implementation and it requires quite a bit of testing

The idea here is to have configurable caching strategies, currently the most sensible (to me) caching strategy would be based on the page object, unique page objects would require fresh SSR content. The page object contains the current URL, the data and the component to be rendered. In the `PageHashStrategy` I'm creating a hash from that object and using that to determine the cache key